### PR TITLE
Adding ability to handle things like LVM volumes and multipath aliases

### DIFF
--- a/fio/fio_run
+++ b/fio/fio_run
@@ -1093,7 +1093,7 @@ if [ $file_count -eq 0 ]; then
 	if [[ $disks_passed != "grab_disks" ]]; then
 		device_list=`echo $disks_passed | sed "s/,/ /g"`
 		for item in $device_list; do
-			value=`file $item`
+			value=`file -L $item` 	#dereference symlinks to handle things like multipath aliases in /dev/mapper
 			echo $value | grep "block special" > /dev/null
 			if [ $? -ne 0 ]; then
 				exit_out "Error: $item is not a block device" 1

--- a/fio/fio_run
+++ b/fio/fio_run
@@ -1093,7 +1093,8 @@ if [ $file_count -eq 0 ]; then
 	if [[ $disks_passed != "grab_disks" ]]; then
 		device_list=`echo $disks_passed | sed "s/,/ /g"`
 		for item in $device_list; do
-			value=`file -L $item` 	#dereference symlinks to handle things like multipath aliases in /dev/mapper
+			#dereference symlinks to handle things like multipath aliases in /dev/mapper
+			value=`file -L $item` 	
 			echo $value | grep "block special" > /dev/null
 			if [ $? -ne 0 ]; then
 				exit_out "Error: $item is not a block device" 1


### PR DESCRIPTION
Adding a "-L" to the "file" command which checks for block devices. This will let us handle things like the symlinks in /dev/mapper which point to LVM volumes, RAID arrays, etc. In other words consider a symlink to a block special to be a block special.