### PR TITLE
adding some spaces to error checks

### DIFF
--- a/fio/fio_run
+++ b/fio/fio_run
@@ -269,7 +269,7 @@ obtain_avg()
                 let "nitems=$nitems+1"
                 field_separ="+"
         done
-        if [ ${nitems} -eq 0]; then
+        if [ ${nitems} -eq 0 ]; then
 		calc=0
 	else
 		# Divide by 3 since the json output includes all three I/O types and we only care about one
@@ -294,7 +294,7 @@ obtain_avg_lat()
                 let "nitems=$nitems+1"
                 field_separ="+"
         done
-        if [ ${nitems} -eq 0]; then
+        if [ ${nitems} -eq 0 ]; then
 		calc=0
 	else
 		# Divide by 3 since the json output includes all three I/O types and we only care about one


### PR DESCRIPTION
# Description
This PR fixes botched error checks caused by forgetting to put a space before a "]"

# Before/After Comparison
Before: if we don't have numbers to crunch the wrapper will see a divide by zero error
After: If we don't have numbers to crunch the number we return will be zero

# Clerical Stuff
This closes #37 

Relates to JIRA: RPOPC-323
