### PR TITLE
We are passing a bad option into package_tool.

### DIFF
--- a/fio/fio_run
+++ b/fio/fio_run
@@ -994,7 +994,11 @@ NO_ARGUMENTS=(
 #
 # Make sure latest is installed. 
 
-test_tools/package_tool --packages fio --no_install $to_no_install
+test_tools/package_tool --packages fio --no_packages $to_no_pkg_install
+if [[ $? -ne 0 ]]; then
+	exit_out "package_tool reported failure for fio package." 1
+fi
+
 # read arguments
 opts=$(getopt \
 	--longoptions "$(printf "%s:," "${ARGUMENT_LIST[@]}")" \


### PR DESCRIPTION
# Description
Changes the argument to package_tool to be correct.

# Before/After Comparison
Before:  Message coming out saying an option o package tool is bad
After:  Proper option is passed, and status of the package_tool command is reported.

# Clerical Stuff
Mention the issue this PR works toward resolving.  If the 
This closes #44 


Relates to JIRA: RPOPC-568
