### PR TITLE
Add pcp support

### DIFF
--- a/fio/fio_run
+++ b/fio/fio_run
@@ -827,6 +827,12 @@ execute_test()
 	fi
 	perform_jobs=`echo $jobs_list | sed "s/,/ /g"`
 
+	# If we're using PCP start logging
+    if [[ $to_use_pcp -eq 1 ]]; then
+        echo "Start PCP"
+        start_pcp ${pcpdir}/ ${test_name} $pcp_cfg
+    fi
+
 	for njobs in  ${perform_jobs}; do
 		disk_used=0
 		for iodepth in $iodepth_list; do
@@ -840,6 +846,12 @@ execute_test()
 			done
 		done
 	done
+
+	# If we're using PCP, stop logging
+    if [[ $to_use_pcp -eq 1 ]]; then
+        echo "Stop PCP"
+        stop_pcp
+	fi
 
 	#
 	# Done testing, process the results.
@@ -1041,6 +1053,11 @@ RESULTSDIR=${curdir}/export_fio_data_$(date "+%Y.%m.%d-%H.%M.%S")
 rm export_fio_data
 mkdir ${RESULTSDIR}
 ln -s ${RESULTSDIR} ${curdir}/export_fio_data
+# Make a PCP results directory if we need it
+if [[ $to_use_pcp -eq 1 ]]; then
+    pcpdir=${RESULTSDIR}/pcp
+    mkdir ${pcpdir}
+fi
 
 install_fio
 iodepth_list=`echo $iodepth_list | sed "s/,/ /g"`
@@ -1101,7 +1118,19 @@ else
 	pdisk_list=`echo ${disks} | sed "s/ /,/g"`
 fi
 
+# Get PCP setup if we're using it
+if [[ $to_use_pcp -eq 1 ]]; then
+    source $TOOLS_BIN/pcp/pcp_commands.inc
+    setup_pcp
+    pcp_cfg=$TOOLS_BIN/pcp/default.cfg
+fi
+
 execute_test
+
+# Shutdown PCP and clean up after ourselves
+if [[ $to_use_pcp -eq 1 ]]; then
+    shutdown_pcp
+fi
 
 if [ $file_count -ne 0 ]; then
 	if [ $lvm_disk -eq 1 ]; then


### PR DESCRIPTION
# Description
This adds PCP support to the wrapper. Test runs have deposited PCP archives alongside the workload results

# Before/After Comparison
Before: No PCP support in the wrapper
After: PCP support in the wrapper

# Clerical Stuff
This closes #47 
Relates to JIRA: RPOPC-596
