### PR TITLE
Restore math to convert block sizes

### DIFF
--- a/fio/fio_run
+++ b/fio/fio_run
@@ -670,7 +670,7 @@ loop_block_sizes()
 	test_index=$3
 
 	for io_size in $bs; do
-		ios=$io_size
+		ios=`echo "${io_size}*1024" | bc`
 		loop_io_tests $out_dir $disk_count $test_index $io_size
 	done
 }

--- a/fio/fio_run
+++ b/fio/fio_run
@@ -670,7 +670,7 @@ loop_block_sizes()
 	test_index=$3
 
 	for io_size in $bs; do
-		ios=`echo "${io_size}*1024" | bc`
+		ios=`echo "${io_size}*1024" | bc`	# This is used to build the fio run file in loop_io_tests, fio likes the option in bytes
 		loop_io_tests $out_dir $disk_count $test_index $io_size
 	done
 }


### PR DESCRIPTION
# Description
When pbench support was removed so was math to convert blocksizes from kb (which the --block_option uses) to bytes (which fio uses)

# Before/After Comparison
Before: blocksizes were fed to fio as bytes
After: blocksizes are fed to fio as kb (pre-pbench-removal behavior)

# Clerical Stuff
Thuis closes #50 
Relates to JIRA: RPOPC-629
