### PR TITLE
Switch to group reporting and adapt data reduction 

### DIFF
--- a/fio/fio_run
+++ b/fio/fio_run
@@ -247,7 +247,7 @@ report_info()
 #
 # Summing function for json formatted bw and iops
 #
-obtain_sum()
+obtain_val()
 {
 	FIELD=${1}
 	value=`jq '.. | select(type == "object" and has('\"$FIELD\"')).'\"$FIELD\"'' fio-results.json | grep -w -v 0.000000`
@@ -297,8 +297,8 @@ reduce_data()
 			if [ -d "$dir" ]; then
 				fname=`echo $dir | cut -d'-' -f 2-30`
 				cd $dir
-				bw=$(obtain_sum "bw_mean")
-				iops=$(obtain_sum "iops")
+				bw=$(obtain_val "bw_mean")
+				iops=$(obtain_val "iops")
 				clat=$(obtain_avg_lat "clat_ns")
                 slat=$(obtain_avg_lat "slat_ns")
                 lat=$(obtain_avg_lat "lat_ns")


### PR DESCRIPTION
# Description
This switches fio's output to "group reporting" mode, allowing us to use the tool's own features to eliminate extra math work in the wrapper and eliminating "average per job per disk" confusion for bandwidth and iops
This also takes that "fixed" output and puts it into a reworked CSV file to support validation, CPT, etc

# Before/After Comparison
Before: 
Metrics were reported on a per-job basis and the wrapper was calculating averages per job per disk instead of aggregate, even for metrics where aggregate makes more sense
Final output file wasn't conducive to machine scraping or human translation to spreadsheets, data was in metric-specific clumps with metadata
Ex: 

<metadata snipped>
njobs:ndisks:iodepth:bw
1:1:1:380029.01
2:1:1:1635242.68
1:1:16:6116681.53

<identical metadata snipped>
njobs:ndisks:iodepth:clat
1:1:1:2664.37
2:1:1:578.78
1:1:16:2663.18

<repeat for slat, lat, iops>

After:
Metrics are calculated in "group reporting" mode, so the wrapper need only pick which of the three reported values is needed for a given metric (one populated, the other two zero)
Final output file is set up better for postprocessing, each data point has its settings "knobs" and all metrics on one line
Ex: 
op:blocksize_KiB:njobs:ndisks:iodepth:bw_KiB_s:iops:clat_us:lat_us:slat_us
# Test meta data start
# ndisks: 1
# disksize: 1.46 TiB
# ioengine: libaio
# Test meta data end
read:1024:1:1:1:2048031.608333:1988.364577:455:502:46
read:1024:2:1:1:2914625.261134:2845.909617:654:702:47
read:1024:1:1:16:5980617.833333:5838.502692:2724:2739:15
read:1024:2:1:16:3953390.491667:3859.315368:8273:8290:17
read:1024:1:1:64:6028052.950000:5884.704804:10862:10874:12
read:1024:2:1:64:4062411.541667:3964.815370:32263:32279:16
read:4:1:1:1:382060.974790:95477.829351:8:10:2
read:4:2:1:1:216790.816667:54178.240181:34:36:2

Metadata is there for bookmarking (human convenience) but can be stripped out for spreadsheeting and isn't pervasive

# Clerical Stuff
This closes #54 
Relates to JIRA: RPOPC-673
