### PR TITLE
Validate fio results.

### DIFF
--- a/fio/fio_run
+++ b/fio/fio_run
@@ -322,6 +322,7 @@ reduce_data()
 	# Now sort the results csv files and place headers
 	#
 	$TOOLS_BIN/test_header_info --test_name ${test_name}  --info_in_dir_name "$file 2,3 4,5,6 9,10" --results_file ${working_dir}/results_fio.csv
+	echo "op:blocksize_KiB:njobs:ndisks:iodepth:bw_KiB_s:iops:clat_us:lat_us:slat_us" >> ${working_dir}/results_fio.csv
 	for list in `ls -d results_*`; do
 		pushd $list > /dev/null
 		op_and_size=`echo $list | cut -d'_' -f 2`
@@ -372,8 +373,7 @@ reduce_data()
 
 reduce_io_data()
 {
-	$TOOLS_BIN/test_header_info --front_matter --results_file $working_dir/results_fio.csv --host $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version $results_version --test_name $test_name --field_header "op,blocksize_KiB,njobs,ndisks,iodepth,bw_KiB_s,iops,clat_us,lat_us,slat_us"
-#	echo "op:blocksize_KiB:njobs:ndisks:iodepth:bw_KiB_s:iops:clat_us:lat_us:slat_us" >> ${working_dir}/results_fio.csv
+	$TOOLS_BIN/test_header_info --front_matter --results_file $working_dir/results_fio.csv --host $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version $results_version --test_name $test_name
 
 	aio_type=`ls -d fio* | cut -d'_' -f 10 | sort -u`
 

--- a/fio/fio_run
+++ b/fio/fio_run
@@ -25,6 +25,22 @@ arguments="$@"
 disk_options=""
 curdir=`pwd`
 
+#
+# Check to see if the test tools directory exists.  If it does, we do not need to
+# clone the repo.
+#
+tools_git=https://github.com/redhat-performance/test_tools-wrappers
+TOOLS_BIN="$HOME/test_tools"
+export TOOLS_BIN
+
+if [ ! -d "${TOOLS_BIN}" ]; then
+	git clone $tools_git $TOOLS_BIN
+	if [ $? -ne 0 ]; then
+		echo  "pulling git $tools_git failed."
+		exit $E_GENERAL
+	fi
+fi
+
 provide_disks()
 {
 	echo You need to designate disks, following are currently not mounted.
@@ -124,7 +140,6 @@ os_vendor=`uname -a | cut -d'.' -f8`
 file_count=0
 file_size=10
 fs_type="xfs"
-tools_git=https://github.com/redhat-performance/test_tools-wrappers
 file_list=""
 file_size_opt=""
 lvm_disk=0
@@ -173,21 +188,13 @@ usage()
 	echo "  --regression: regression run"
 	echo "  --runtime: run for the designated period, 60 seconds is the default"
 	echo "  --test_type: type of io doing."
-	source test_tools/general_setup --usage
+	source ${TOOLS_BIN}/general_setup --usage
 }
 #
 # Clone the repo that contains the common code and tools
 #
 found=0
 for arg in "$@"; do
-	if [ $found -eq 1 ]; then
-		tools_git=$arg
-		found=0
-	fi
-	if [[ $arg == "--tools_git" ]]; then
-		found=1
-	fi
-
 	if [[ $found -eq 2 ]]; then
 		string1=`echo $arg | cut -d: -f2 | sed "s/;/ /g"`
 		for i in $string1; do
@@ -211,16 +218,6 @@ for arg in "$@"; do
 	fi
 done
 
-#
-# Check to see if the test tools directory exists.  If it does, we do not need to
-# clone the repo.
-#
-if [ ! -d "test_tools" ]; then
-	git clone $tools_git test_tools
-	if [ $? -ne 0 ]; then
-		exit_out "pulling git $tools_git failed." 1
-	fi
-fi
 
 # Variables set by general setup.
 #
@@ -234,7 +231,7 @@ fi
 # to_tuned_setting: tuned setting
 #
 
-source test_tools/general_setup "$@"
+source ${TOOLS_BIN}/general_setup "$@"
 
 #
 # Report information
@@ -427,7 +424,7 @@ create_and_mount_fs()
 		lvm_disk_to_use=`echo $disks | sed "s/ /,/g"`
 		$TOOLS_BIN/lvm_create --devices ${lvm_disk_to_use} --lvm_vol fio --lvm_grp fio
 		if [ $? -ne 0 ]; then
-			exit_out "$TOOLS_BIN/lvm_create --devices ${lvm_disk_to_use} --lvm_vol fio --lvm_grp fio failed" 1
+			exit_out "$TOOLS_BIN/lvm_create --devices ${lvm_disk_to_use} --lvm_vol fio --lvm_grp fio failed" $E_GENERAL
 		fi
 		#
 		# Sanity setup
@@ -438,7 +435,7 @@ create_and_mount_fs()
 		#
 		$TOOLS_BIN/create_filesystem --fs_type $fs_type --mount_dir /perf1 --device /dev/fio/fio
 		if [ $? -ne 0 ]; then
-			exit_out "$TOOLS_BIN/create_filesystem --fs_type $fs_type --mount_dir /perf1 --device /dev/fio/fio failed" 1
+			exit_out "$TOOLS_BIN/create_filesystem --fs_type $fs_type --mount_dir /perf1 --device /dev/fio/fio failed" $E_GENERAL
 		fi
 		#
 		# Build the file list.
@@ -461,7 +458,7 @@ create_and_mount_fs()
 			mkdir -p ${mount_pnt} >& /dev/null
 			$TOOLS_BIN/create_filesystem --fs_type $fs_type --mount_dir $mount_pnt --device $device
 			if [ $? -ne 0 ]; then
-				exit_out "$TOOLS_BIN/create_filesystem --fs_type $fs_type --mount_dir /perf1 --device /dev/fio/fio failed" 1
+				exit_out "$TOOLS_BIN/create_filesystem --fs_type $fs_type --mount_dir /perf1 --device /dev/fio/fio failed" $E_GENERAL
 			fi
 			mount_list=${mount_list}${seper}${mount_pnt}
 			seper=" "
@@ -528,7 +525,7 @@ obtain_disks()
 		# to make sure the disk exist.
 		#
 		if [ $? -ne 0 ]; then
-			exit_out "grab disks failed." 1
+			exit_out "grab disks failed." $E_GENERAL
 		fi
 
 		max_disks=`echo $results | cut -d: -f 2`
@@ -563,7 +560,7 @@ install_fio()
 				#
 				# fio does not appear to be installed, bail out.
 				#
-				exit_out "fio does not exist in /bin either, aborting." 1
+				exit_out "fio does not exist in /bin either, aborting." $E_GENERAL
 			fi
 		fi
 	fi
@@ -968,7 +965,7 @@ execute_test()
 		mv /tmp/${test_name}.out ${curdir}/export_fio_data
 		echo $run_results >> ${curdir}/export_fio_data/test_results_report
 
-	${curdir}/test_tools/save_results --curdir $curdir --home_root $to_home_root --copy_dir ${RESULTSDIR} --test_name $test_name --tuned_setting=$to_tuned_setting --version NONE --user $to_user
+	${TOOLS_BIN}/save_results --curdir $curdir --home_root $to_home_root --copy_dir ${RESULTSDIR} --test_name $test_name --tuned_setting=$to_tuned_setting --version NONE --user $to_user
 }
 
 #
@@ -1001,9 +998,10 @@ NO_ARGUMENTS=(
 )
 
 # Install needed packages based on what's listed in the wrapper's json file
-${TOOLS_BIN}/package_tool --no_packages $to_no_pkg_install --wrapper_config ${run_dir}/fio-wrapper.json
-if [[ $? -ne 0 ]]; then
-        exit_out "package_tool reported failure installing dependencies." 1
+package_tool --no_packages $to_no_pkg_install --wrapper_config ${run_dir}/fio-wrapper.json
+rtc=$?
+if [[ $rtc -ne 0 ]]; then
+        exit_out "package_tool reported failure installing dependencies." $rtc
 fi
 
 # read arguments
@@ -1132,11 +1130,11 @@ if [ $file_count -eq 0 ]; then
 			value=`file -L $item` 	
 			echo $value | grep "block special" > /dev/null
 			if [ $? -ne 0 ]; then
-				exit_out "Error: $item is not a block device" 1
+				exit_out "Error: $item is not a block device" $E_GENERAL
 			fi
-			test_tools/detect_mounts $item
+			${TOOLS_BIN}/detect_mounts $item
 			if [ $? -ne 0 ]; then
-				exit_out "Error: $item is mounted." 1
+				exit_out "Error: $item is mounted." $E_GENERAL
 			fi
 		done
 	fi

--- a/fio/fio_run
+++ b/fio/fio_run
@@ -24,6 +24,8 @@ test_name="fio"
 arguments="$@"
 disk_options=""
 curdir=`pwd`
+header_txt="op,blocksize_KiB,njobs,ndisks,iodepth,bw_KiB_s,iops,clat_us,lat_us,slat_us,Start_Date,End_Date"
+script_dir=$(realpath $(dirname $0))
 
 #
 # Check to see if the test tools directory exists.  If it does, we do not need to
@@ -37,7 +39,7 @@ if [ ! -d "${TOOLS_BIN}" ]; then
 	git clone $tools_git $TOOLS_BIN
 	if [ $? -ne 0 ]; then
 		echo  "pulling git $tools_git failed."
-		exit $E_GENERAL
+		exit 101
 	fi
 fi
 
@@ -319,7 +321,7 @@ reduce_data()
 	# Now sort the results csv files and place headers
 	#
 	$TOOLS_BIN/test_header_info --test_name ${test_name}  --info_in_dir_name "$file 2,3 4,5,6 9,10" --results_file ${working_dir}/results_fio.csv
-	echo "op:blocksize_KiB:njobs:ndisks:iodepth:bw_KiB_s:iops:clat_us:lat_us:slat_us" >> ${working_dir}/results_fio.csv
+	echo $header_txt >> ${working_dir}/results_fio.csv
 	for list in `ls -d results_*`; do
 		pushd $list > /dev/null
 		op_and_size=`echo $list | cut -d'_' -f 2`
@@ -400,6 +402,23 @@ reduce_io_data()
 			popd
 		done
 	done
+	#
+	# Validate data
+	#
+	tmp_file=$(mktemp /tmp/fio_results.XXXXX)
+	echo $header_txt > $tmp_file
+	grep -v "^#" $working_dir/results_fio.csv | grep -v "^op" >> $tmp_file
+	${TOOLS_BIN}/csv_to_json $to_json_flags --csv_file $tmp_file --output_file results_fio.json
+	rtc=$?
+	if [[ $rtc -ne 0 ]]; then
+		exit out "Error: csv_to_json failed" $rtc
+	fi
+	${TOOLS_BIN}/verify_results $to_verify_flags --schema_file $script_dir/results_fio_schema.py --class_name Fio_Results --file results_fio.json
+
+	rtc=$?
+	if [[ $rtc -ne 0 ]]; then
+		exit_out "Error: fio data verification failed" $rtc
+	fi
 }
 	
 # Create the required file systems.
@@ -1223,6 +1242,7 @@ execute_test
 if [[ $to_use_pcp -eq 1 ]]; then
     shutdown_pcp
 fi
+
 
 if [ $file_count -ne 0 ]; then
 	if [ $lvm_disk -eq 1 ]; then

--- a/fio/results_fio_schema.py
+++ b/fio/results_fio_schema.py
@@ -4,6 +4,15 @@ from enum import Enum
 class Benchmark(Enum):
     read = "read"
     write = "write"
+    trim = "trim"
+    randread = "randread"
+    randwrite = "randwrite"
+    randtrim = "randtrim"
+    rw= "rw"
+    readwrite = "randwrite"
+    randrw = "randrw"
+    trimwrite = "trimwrite"
+    randtrimwrite = "randtrimwrite"
 
 class Fio_Results (pydantic.BaseModel):
     op: Benchmark

--- a/fio/results_fio_schema.py
+++ b/fio/results_fio_schema.py
@@ -1,0 +1,20 @@
+import pydantic
+import datetime
+from enum import Enum
+class Benchmark(Enum):
+    read = "read"
+    write = "write"
+
+class Fio_Results (pydantic.BaseModel):
+    op: Benchmark
+    blocksize_KiB: int = pydantic.Field(gt=0)
+    njobs: int = pydantic.Field(gt=0)
+    ndisks: int = pydantic.Field(gt=0)
+    iodepth: int = pydantic.Field(gt=0)
+    bw_KiB_s: float = pydantic.Field(gt=0, allow_inf_nan=False)
+    iops: float = pydantic.Field(gt=0, allow_inf_nan=False)
+    clat_us: int = pydantic.Field(ge=0)
+    lat_us: int = pydantic.Field(ge=0)
+    slat_us: int = pydantic.Field(ge=0)
+    Start_Date: datetime.datetime
+    End_Date: datetime.datetime


### PR DESCRIPTION
# Description
1) Validates fio results
2) Uses error codes from test_tools/error_codes
3) Updates test_tools creation

# Before/After Comparison
Before: No validation of results
After: Results are validated.

# Clerical Stuff
This closes #59 
to close the issue out automatically.

Relates to JIRA: RPOPC-818

Testing Done

Test command executed

Verified verification of successful l returns expected rtc.


Verified bad data results in expected rtc.

22.bw_KiB_s
  Input should be a valid number, unable to parse string as a number [type=float_parsing, input_value='bad128407.800000', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/float_parsing
23.bw_KiB_s
  Input should be a valid number, unable to parse string as a number [type=float_parsing, input_value='bad128054.250000', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/float_parsing
Error: fio data verification failed
[root@ip-170-0-25-94 ec2-user]# ./fio.cmd^C
[root@ip-170-0-25-94 ec2-user]# echo $?
106

