### PR TITLE
Update how we get test_tools

### DIFF
--- a/fio/fio_run
+++ b/fio/fio_run
@@ -35,14 +35,43 @@ tools_git=https://github.com/redhat-performance/test_tools-wrappers
 TOOLS_BIN="$HOME/test_tools"
 export TOOLS_BIN
 
-if [ ! -d "${TOOLS_BIN}" ]; then
-	git clone $tools_git $TOOLS_BIN
-	if [ $? -ne 0 ]; then
-		echo  "pulling git $tools_git failed."
-		exit 101
-	fi
-fi
+attempt_tools_wget()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                wget ${tools_git}/archive/refs/heads/main.zip
+                if [[ $? -eq 0 ]]; then
+                        unzip -q main.zip
+                        mv test_tools-wrappers-main ${TOOLS_BIN}
+                        rm main.zip
+                fi
+        fi
+}
 
+attempt_tools_curl()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                curl -L -O ${tools_git}/archive/refs/heads/main.zip
+                if [[ $? -eq 0 ]]; then
+                        unzip -q main.zip
+                        mv test_tools-wrappers-main ${TOOLS_BIN}
+                        rm main.zip
+                fi
+        fi
+}
+
+attempt_tools_git()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                git clone $tools_git "$TOOLS_BIN"
+                if [ $? -ne 0 ]; then
+                        exit_out "Error: pulling git $tools_git failed." 101
+                fi
+        fi
+}
+
+attempt_tools_wget
+attempt_tools_curl
+attempt_tools_git
 provide_disks()
 {
 	echo You need to designate disks, following are currently not mounted.


### PR DESCRIPTION
# Description
Updates the way we pull the test_tools

# Before/After Comparison
Before:  We only pulled via git
After:  We will try via wget, curl, git.

# Clerical Stuff
This closes #61  

Relates to JIRA: RPOPC-877

Testing
Ran fio with the following scenario file
global:
  ssh_key_file: replace_your_ssh_key
  terminate_cloud: 1
  os_vendor: rhel
  results_prefix: fio_results
  os_vendor: rhel
  system_type: aws
  cloud_os_id: ami-035032ea878eca201
systems:
  system1:
    tests: "fio"
    host_config: "m7i.2xlarge:Disks;type=gp3;throughput=1000;disk_iops=16000;size=3000;number=2"

Produced the following csv file
op,blocksize_KiB,njobs,ndisks,iodepth,bw_KiB_s,iops,clat_us,lat_us,slat_us,Start_Date,End_Date
read,1024,1,1,1,602875.858333,588.386763,1665,1696,30,2026-03-16T09:19:00Z,2026-03-16T09:21:05Z
read,1024,1,1,16,1030796.341667,1005.940875,15201,15902,701,2026-03-16T09:36:48Z,2026-03-16T09:38:53Z
read,1024,1,1,64,1030908.075000,1005.932542,62612,63604,992,2026-03-16T09:54:36Z,2026-03-16T09:56:41Z
read,4,1,1,1,6024.916667,1505.354122,656,662,5,2026-03-16T09:14:33Z,2026-03-16T09:16:38Z
read,4,1,1,16,64045.933333,16000.724994,998,999,1,2026-03-16T09:32:21Z,2026-03-16T09:34:26Z
read,4,1,1,64,64041.233333,16000.308323,3937,3999,61,2026-03-16T09:50:09Z,2026-03-16T09:52:14Z
write,1024,1,1,1,305392.858333,298.047516,3307,3351,43,2026-03-16T09:21:13Z,2026-03-16T09:23:19Z
write,1024,1,1,16,1030847.975000,1005.940924,15234,15903,668,2026-03-16T09:39:01Z,2026-03-16T09:41:06Z
write,1024,1,1,64,1030908.125000,1005.940924,62612,63604,992,2026-03-16T09:56:49Z,2026-03-16T09:58:54Z
write,4,1,1,1,3895.483333,973.391888,1014,1024,9,2026-03-16T09:16:47Z,2026-03-16T09:18:52Z
write,4,1,1,16,64204.008333,16040.716327,996,997,1,2026-03-16T09:34:34Z,2026-03-16T09:36:39Z
write,4,1,1,64,64040.700000,16000.324989,3937,3999,61,2026-03-16T09:52:22Z,2026-03-16T09:54:27Z

op,blocksize_KiB,njobs,ndisks,iodepth,bw_KiB_s,iops,clat_us,lat_us,slat_us,Start_Date,End_Date
read,1024,1,2,1,1200901.750000,1172.038799,1672,1703,30,2026-03-16T09:27:54Z,2026-03-16T09:29:59Z
read,1024,1,2,16,1221494.050000,1191.875094,25617,26843,1225,2026-03-16T09:45:42Z,2026-03-16T09:47:47Z
read,1024,1,2,64,1221595.658333,1191.871897,105669,107343,1674,2026-03-16T10:03:30Z,2026-03-16T10:05:35Z
read,4,1,2,1,12642.016667,3158.723677,627,631,4,2026-03-16T09:23:27Z,2026-03-16T09:25:32Z
read,4,1,2,16,128069.700000,32001.183314,998,999,1,2026-03-16T09:41:15Z,2026-03-16T09:43:20Z
read,4,1,2,64,128050.066667,32000.658311,3937,3999,61,2026-03-16T09:59:03Z,2026-03-16T10:01:08Z
write,1024,1,2,1,605752.933333,591.168554,3334,3379,44,2026-03-16T09:30:07Z,2026-03-16T09:32:12Z
write,1024,1,2,16,1221456.508333,1191.873495,25667,26844,1176,2026-03-16T09:47:55Z,2026-03-16T09:50:01Z
write,1024,1,2,64,1221502.000000,1191.865164,105697,107372,1674,2026-03-16T10:05:43Z,2026-03-16T10:07:48Z
write,4,1,2,1,7772.916667,1942.200482,1018,1026,8,2026-03-16T09:25:40Z,2026-03-16T09:27:46Z
write,4,1,2,16,128445.991667,32096.015867,995,996,1,2026-03-16T09:43:28Z,2026-03-16T09:45:33Z
write,4,1,2,64,128094.516667,32000.716643,3937,3999,61,2026-03-16T10:01:16Z,2026-03-16T10:03:22Z

Test ran as expected.