### PR TITLE
Fix test_tools loading

### DIFF
--- a/fio/fio_run
+++ b/fio/fio_run
@@ -35,22 +35,17 @@ tools_git=https://github.com/redhat-performance/test_tools-wrappers
 TOOLS_BIN="$HOME/test_tools"
 export TOOLS_BIN
 
-attempt_tools_wget()
+exit_out()
 {
-        if [[ ! -d "$TOOLS_BIN" ]]; then
-                wget ${tools_git}/archive/refs/heads/main.zip
-                if [[ $? -eq 0 ]]; then
-                        unzip -q main.zip
-                        mv test_tools-wrappers-main ${TOOLS_BIN}
-                        rm main.zip
-                fi
-        fi
+	echo $1
+	exit $2
 }
 
-attempt_tools_curl()
+attempt_tools_generic()
 {
+	method="$1"
         if [[ ! -d "$TOOLS_BIN" ]]; then
-                curl -L -O ${tools_git}/archive/refs/heads/main.zip
+                $method ${tools_git}/archive/refs/heads/main.zip
                 if [[ $? -eq 0 ]]; then
                         unzip -q main.zip
                         mv test_tools-wrappers-main ${TOOLS_BIN}
@@ -69,9 +64,10 @@ attempt_tools_git()
         fi
 }
 
-attempt_tools_wget
-attempt_tools_curl
+attempt_tools_generic "wget"
+attempt_tools_generic "curl -L -O "
 attempt_tools_git
+
 provide_disks()
 {
 	echo You need to designate disks, following are currently not mounted.
@@ -195,12 +191,6 @@ if [ ! -f "/tmp/${test_name}.out" ]; then
 	fi
         exit $rtc
 fi
-
-exit_out()
-{
-	echo $1
-	exit $2
-}
 
 usage()
 {


### PR DESCRIPTION
# Description
1) Removes duplicate code in the test_tools new code
2) Fixes exit_out not existing

# Before/After Comparison
Before: If we failed, we would get an error calling exit_out as it does not exist.
After: Error no longer occurs.

# Clerical Stuff
This closes #63 

Relates to JIRA: RPOPC-899

Testing done:
Verified each method works, and we get a proper message if we fail.
